### PR TITLE
fix: comm コマンドとの互換性を確保するために、sort -n を sort に変更した

### DIFF
--- a/.github/workflows/_addIssueToProject.yml
+++ b/.github/workflows/_addIssueToProject.yml
@@ -89,7 +89,7 @@ jobs:
           existing_issues=$(echo "$existing_issues_raw" \
             | awk 'NF' \
             | { grep -E '^[0-9]+$' || true; } \
-            | sort -n \
+            | sort \
             | uniq)
 
           if [ -z "$existing_issues" ] && [ -n "$existing_issues_raw" ]; then
@@ -106,7 +106,7 @@ jobs:
             | jq -r '.[].number' \
             | awk 'NF' \
             | { grep -E '^[0-9]+$' || true; } \
-            | sort -n \
+            | sort \
             | uniq)
 
           if [ -z "$all_issues" ]; then
@@ -119,8 +119,8 @@ jobs:
           echo "Debug - existing_issues count: $(echo "$existing_issues" | { grep -c . || echo 0; })"
 
           if [ -n "$all_issues" ] && [ -n "$existing_issues" ]; then
-            echo "$all_issues" | tr ' ' '\n' | { grep -E '^[0-9]+$' || true; } | sort -n > /tmp/all_issues_sorted
-            echo "$existing_issues" | tr ' ' '\n' | { grep -E '^[0-9]+$' || true; } | sort -n > /tmp/existing_issues_sorted
+            echo "$all_issues" | tr ' ' '\n' | { grep -E '^[0-9]+$' || true; } | sort > /tmp/all_issues_sorted
+            echo "$existing_issues" | tr ' ' '\n' | { grep -E '^[0-9]+$' || true; } | sort > /tmp/existing_issues_sorted
             missing_issues=$(comm -23 /tmp/all_issues_sorted /tmp/existing_issues_sorted | tr '\n' ' ' | xargs)
           elif [ -n "$all_issues" ] && [ -z "$existing_issues" ]; then
             missing_issues=$(echo "$all_issues" | tr '\n' ' ' | xargs)


### PR DESCRIPTION
## Summary
- `_addIssueToProject.yml` の `sort -n`（数値順ソート）を `sort`（辞書順ソート）に4箇所変更
- `comm -23` コマンドは辞書順ソートされた入力を前提とするが、`sort -n` を使用していたためソート順が不一致となり差分検出が正しく動作しなかった
- これにより既にプロジェクトに追加済みの issue が毎回再追加される冪等性バグが発生していた

## Test plan
- [ ] ワークフローを手動実行し、既にプロジェクトに存在する issue が再追加されないことを確認する
- [ ] 新しい issue を作成し、ワークフロー実行後にプロジェクトに追加されることを確認する