### PR TITLE
GH_PAT 廃止に伴い addIssueToProject ワークフローを一時無効化する

### DIFF
--- a/.github/workflows/_addIssueToProject.yml
+++ b/.github/workflows/_addIssueToProject.yml
@@ -1,10 +1,36 @@
 name: addIssueToProject
 
+# ============================================================================
+# このワークフローは GH_PAT 廃止作業に伴い一時的に無効化しています。
+# 現在は通知ステップ「Notify temporarily disabled」のみが動作し、実処理は
+# 下部に各行頭「# 」付きでコメントアウト保存しています。
+#
+# 復旧の前提（重要）:
+#   「# 」の一括除去（blind sed）はしないこと。この説明コメント群も「# 」で
+#   始まるため壊れます。復活対象は “元の YAML コード行” だけで、説明コメントは削除します。
+#
+# 【緊急ロールバック】GH_PAT がまだ使えるなら、これだけで旧動作へ戻ります:
+#   _addIssueToProject.yml（このファイル）:
+#     1. 下の「===== 元処理 =====」より後ろの各行頭「# 」を外す（本体を復活）
+#     2. 「Notify temporarily disabled」ステップ（run の echo 群）を削除する
+#     3. 直下 on.workflow_call の secrets ブロック（secrets: / GH_PAT: / required: true）を復活
+#   addIssueToProject.yml（呼び出し側）も必ずセットで:
+#     4. schedule ブロックを復活
+#     5. jobs.add-issues の secrets（GH_PAT 受け渡し）を復活
+#   ※ 手順3と5は必ず同時に行うこと。片方だけだと secret 不整合で定義エラーになります。
+#
+# 【恒久対応】GH_PAT を使わずに復旧する場合（推奨。詳細・完了条件は issue #17）:
+#   - 認証を actions/create-github-app-token（org install + organization_projects:write）へ置換
+#   - 対象が user 所有 Project のため、Organization 移行に伴い下記も書き換え必須:
+#       GraphQL の user(login: "kentanishida") → organization(login: "<org>")（2 箇所）
+#       projectV2(number: 6) と expected_project_id を org 側 Project の値へ更新
+# ============================================================================
 on:
   workflow_call:
-    secrets:
-      GH_PAT:
-        required: true
+    # ↓ 復旧時は次の secrets ブロック（3行）の「# 」を外す。この説明行は削除する ↓
+    # secrets:
+    #   GH_PAT:
+    #     required: true
 
 permissions: {}
 
@@ -13,250 +39,263 @@ jobs:
     runs-on: ubicloud-standard-2-ubuntu-2404
 
     steps:
-      - name: Get issues not in project
-        id: get-issues
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+      # GH_PAT 廃止作業中の一時ステップ。復旧時にこのステップは削除する
+      - name: Notify temporarily disabled
         run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "::error::GH_PAT secret is not set. Please configure it in Settings > Secrets > Actions."
-            exit 1
-          fi
+          echo "::notice::addIssueToProject はただいまおやすみ中です 🚧"
+          echo "----------------------------------------------------------------"
+          echo "🚧 issue を Project へ自動追加するワークフローは一時停止しています。"
+          echo "理由: GH_PAT（Personal Access Token）をセキュリティ上の理由で廃止するためです。"
+          echo "今後: GitHub App（org install + organization_projects:write）へ移行後に復旧します。"
+          echo "復旧手順は本ファイル冒頭のコメントを参照してください。"
+          echo "----------------------------------------------------------------"
 
-          # 現在は kentanishida/free-pjt のプロジェクト管理のみで使用しているためハードコードで運用。他リポ展開時に inputs 化を検討する
-          echo "Validating project access..."
-          if ! validation=$(gh api graphql -f query='
-            query {
-              user(login: "kentanishida") {
-                projectV2(number: 6) {
-                  id
-                  title
-                }
-              }
-            }
-          ' 2>&1); then
-            echo "::error::GraphQL API request failed. Response: $validation"
-            echo "::error::Check that GH_PAT has 'project' and 'repo' scopes, and that GitHub API is accessible."
-            exit 1
-          fi
-
-          if echo "$validation" | jq -e '.errors | length > 0' > /dev/null 2>&1; then
-            error_msg=$(echo "$validation" | jq -r '.errors[0].message // "Unknown GraphQL error"')
-            echo "::error::GraphQL returned errors: $error_msg"
-            exit 1
-          fi
-
-          if echo "$validation" | jq -e '.data.user.projectV2 == null' > /dev/null 2>&1; then
-            echo "::error::Project not found. Verify project number (6) and user (kentanishida) are correct."
-            exit 1
-          fi
-
-          actual_project_id=$(echo "$validation" | jq -r '.data.user.projectV2.id')
-          # 現在は kentanishida/free-pjt のプロジェクト管理のみで使用しているためハードコードで運用。他リポ展開時に inputs 化を検討する
-          expected_project_id="PVT_kwHOBUR8Xc4A8hFH"
-          if [ "$actual_project_id" != "$expected_project_id" ]; then
-            echo "::error::Project ID mismatch. Expected: $expected_project_id, Got: $actual_project_id"
-            exit 1
-          fi
-
-          project_title=$(echo "$validation" | jq -r '.data.user.projectV2.title')
-          echo "Validated project: $project_title ($actual_project_id)"
-          echo "project_id=$actual_project_id" >> "$GITHUB_OUTPUT"
-
-          # 現在は kentanishida/free-pjt のプロジェクト管理のみで使用しているためハードコードで運用。他リポ展開時に inputs 化を検討する
-          echo "Getting existing project items (all pages)..."
-          if ! existing_issues_raw=$(gh api graphql --paginate -f query='
-            query($endCursor: String) {
-              user(login: "kentanishida") {
-                projectV2(number: 6) {
-                  items(first: 100, after: $endCursor) {
-                    nodes {
-                      content {
-                        ... on Issue {
-                          number
-                        }
-                      }
-                    }
-                    pageInfo {
-                      hasNextPage
-                      endCursor
-                    }
-                  }
-                }
-              }
-            }
-          ' --jq '.data.user.projectV2.items.nodes[].content.number // empty' 2>&1); then
-            echo "::error::Failed to fetch existing project items. Response: $existing_issues_raw"
-            exit 1
-          fi
-          existing_issues=$(echo "$existing_issues_raw" \
-            | awk 'NF' \
-            | { grep -E '^[0-9]+$' || true; } \
-            | sort \
-            | uniq)
-
-          if [ -z "$existing_issues" ] && [ -n "$existing_issues_raw" ]; then
-            echo "::warning::Raw project items data was non-empty but no valid issue numbers were extracted. Raw (first 500 chars): ${existing_issues_raw:0:500}"
-          fi
-
-          # gh issue list はローカルの git リポジトリからリポジトリを推定するため、checkout なしでは --repo の指定が必要
-          echo "Getting all open issues..."
-          if ! all_issues_raw=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --json number --limit 10000 2>&1); then
-            echo "::error::Failed to fetch open issues. Response: $all_issues_raw"
-            exit 1
-          fi
-          all_issues=$(echo "$all_issues_raw" \
-            | jq -r '.[].number' \
-            | awk 'NF' \
-            | { grep -E '^[0-9]+$' || true; } \
-            | sort \
-            | uniq)
-
-          if [ -z "$all_issues" ]; then
-            echo "No open issues found. Nothing to do."
-            echo "missing_issues=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Debug - all_issues count: $(echo "$all_issues" | { grep -c . || echo 0; })"
-          echo "Debug - existing_issues count: $(echo "$existing_issues" | { grep -c . || echo 0; })"
-
-          if [ -n "$all_issues" ] && [ -n "$existing_issues" ]; then
-            echo "$all_issues" | tr ' ' '\n' | { grep -E '^[0-9]+$' || true; } | sort > /tmp/all_issues_sorted
-            echo "$existing_issues" | tr ' ' '\n' | { grep -E '^[0-9]+$' || true; } | sort > /tmp/existing_issues_sorted
-            missing_issues=$(comm -23 /tmp/all_issues_sorted /tmp/existing_issues_sorted | tr '\n' ' ' | xargs)
-          elif [ -n "$all_issues" ] && [ -z "$existing_issues" ]; then
-            missing_issues=$(echo "$all_issues" | tr '\n' ' ' | xargs)
-          else
-            missing_issues=""
-          fi
-
-          echo "Issues not in project: $missing_issues"
-          delimiter="ghadelimiter_$(openssl rand -hex 8)"
-          echo "missing_issues<<${delimiter}" >> "$GITHUB_OUTPUT"
-          echo "$missing_issues" >> "$GITHUB_OUTPUT"
-          echo "${delimiter}" >> "$GITHUB_OUTPUT"
-
-      - name: Add missing issues to project
-        id: add-missing-issues
-        if: steps.get-issues.outputs.missing_issues != ''
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-          MISSING_ISSUES: ${{ steps.get-issues.outputs.missing_issues }}
-          PROJECT_ID: ${{ steps.get-issues.outputs.project_id }}
-        run: |
-          if [ -z "$PROJECT_ID" ]; then
-            echo "::error::PROJECT_ID is empty. The get-issues step may have failed to set it."
-            exit 1
-          fi
-
-          failed_count=0
-          success_count=0
-
-          for issue_number in $MISSING_ISSUES; do
-            if ! echo "$issue_number" | grep -qE '^[0-9]+$'; then
-              echo "::warning::Skipping non-numeric value: $issue_number"
-              continue
-            fi
-
-            echo "Adding issue #$issue_number to project..."
-
-            content_id_response=""
-            max_attempts=3
-            for attempt in $(seq 1 $max_attempts); do
-              raw_response=$(gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number" --include 2>&1) || true
-
-              if echo "$raw_response" | head -1 | grep -q '^HTTP/'; then
-                status_code=$(echo "$raw_response" | head -1 | awk '{print $2}' | tr -d '\r')
-                response_body=$(echo "$raw_response" | sed '1,/^[[:space:]]*$/d')
-              else
-                echo "::warning::No HTTP response received for issue #$issue_number. Attempt $attempt/$max_attempts. Raw output (first 500 chars): ${raw_response:0:500}"
-                status_code=""
-                response_body=""
-                if [ "$attempt" -lt "$max_attempts" ]; then
-                  sleep $((attempt * 5))
-                fi
-                continue
-              fi
-
-              if [ "$status_code" = "200" ]; then
-                content_id_response=$(echo "$response_body" | jq -r '.node_id' 2>/dev/null)
-                break
-              else
-                if [ "$status_code" = "429" ] || [ "$status_code" = "403" ]; then
-                  warn_prefix="Forbidden or rate limited"
-                else
-                  warn_prefix="Unexpected status"
-                fi
-                echo "::warning::${warn_prefix} (HTTP $status_code) for issue #$issue_number. Attempt $attempt/$max_attempts."
-                echo "::warning::Response body (first 500 chars): ${response_body:0:500}"
-                if echo "$status_code" | grep -qE '^4[0-9][0-9]$' && [ "$status_code" != "429" ] && [ "$status_code" != "403" ]; then
-                  break
-                fi
-                if [ "$attempt" -lt "$max_attempts" ]; then
-                  sleep $((attempt * 5))
-                fi
-              fi
-            done
-
-            if [ -z "$content_id_response" ] || [ "$content_id_response" = "null" ]; then
-              echo "::warning::Failed to get node_id for issue #$issue_number after $max_attempts attempts. Last HTTP status: $status_code"
-              failed_count=$((failed_count + 1))
-              sleep 1
-              continue
-            fi
-
-            if ! mutation_response=$(gh api graphql -f query='
-              mutation($projectId: ID!, $contentId: ID!) {
-                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-                  item {
-                    id
-                  }
-                }
-              }
-            ' -f projectId="$PROJECT_ID" -f contentId="$content_id_response" 2>&1); then
-              echo "::warning::Failed to add issue #$issue_number to project. Response: $mutation_response"
-              failed_count=$((failed_count + 1))
-            elif echo "$mutation_response" | jq -e '.errors | length > 0' > /dev/null 2>&1; then
-              error_msg=$(echo "$mutation_response" | jq -r '.errors[0].message // "Unknown error"')
-              echo "::warning::GraphQL error adding issue #$issue_number: $error_msg"
-              failed_count=$((failed_count + 1))
-            elif echo "$mutation_response" | jq -e '.data.addProjectV2ItemById.item.id' > /dev/null 2>&1; then
-              echo "Successfully added issue #$issue_number"
-              success_count=$((success_count + 1))
-            else
-              echo "::warning::Unexpected response for issue #$issue_number: $mutation_response"
-              failed_count=$((failed_count + 1))
-            fi
-
-            sleep 1
-          done
-
-          total=$((success_count + failed_count))
-          echo "Results: $success_count succeeded, $failed_count failed out of $total total"
-
-          echo "success_count=$success_count" >> "$GITHUB_OUTPUT"
-          echo "failed_count=$failed_count" >> "$GITHUB_OUTPUT"
-
-          if [ "$failed_count" -gt 0 ]; then
-            echo "::error::$failed_count issue(s) failed to be added to the project"
-            exit 1
-          fi
-
-      - name: Summary
-        if: always()
-        env:
-          MISSING_ISSUES: ${{ steps.get-issues.outputs.missing_issues }}
-          SUCCESS_COUNT: ${{ steps.add-missing-issues.outputs.success_count }}
-          FAILED_COUNT: ${{ steps.add-missing-issues.outputs.failed_count }}
-        run: |
-          if [ -z "$MISSING_ISSUES" ]; then
-            echo "All issues are already in the project"
-          elif [ -n "$SUCCESS_COUNT" ]; then
-            echo "Results: $SUCCESS_COUNT succeeded, $FAILED_COUNT failed"
-            if [ "$FAILED_COUNT" -gt 0 ]; then
-              echo "::warning::Some issues failed to be added. Check the logs above for details."
-            fi
-          else
-            echo "::warning::Add step did not complete. Check the logs above for details."
-          fi
+      # ===== 元処理（GH_PAT 廃止前） =====
+      # 復旧時はこの区切りより後ろの “各行頭の「# 」のみ” を外す。上の説明コメントは外さず削除する。
+#       - name: Get issues not in project
+#         id: get-issues
+#         env:
+#           GH_TOKEN: ${{ secrets.GH_PAT }}
+#         run: |
+#           if [ -z "$GH_TOKEN" ]; then
+#             echo "::error::GH_PAT secret is not set. Please configure it in Settings > Secrets > Actions."
+#             exit 1
+#           fi
+#
+#           # 現在は kentanishida/free-pjt のプロジェクト管理のみで使用しているためハードコードで運用。他リポ展開時に inputs 化を検討する
+#           echo "Validating project access..."
+#           if ! validation=$(gh api graphql -f query='
+#             query {
+#               user(login: "kentanishida") {
+#                 projectV2(number: 6) {
+#                   id
+#                   title
+#                 }
+#               }
+#             }
+#           ' 2>&1); then
+#             echo "::error::GraphQL API request failed. Response: $validation"
+#             echo "::error::Check that GH_PAT has 'project' and 'repo' scopes, and that GitHub API is accessible."
+#             exit 1
+#           fi
+#
+#           if echo "$validation" | jq -e '.errors | length > 0' > /dev/null 2>&1; then
+#             error_msg=$(echo "$validation" | jq -r '.errors[0].message // "Unknown GraphQL error"')
+#             echo "::error::GraphQL returned errors: $error_msg"
+#             exit 1
+#           fi
+#
+#           if echo "$validation" | jq -e '.data.user.projectV2 == null' > /dev/null 2>&1; then
+#             echo "::error::Project not found. Verify project number (6) and user (kentanishida) are correct."
+#             exit 1
+#           fi
+#
+#           actual_project_id=$(echo "$validation" | jq -r '.data.user.projectV2.id')
+#           # 現在は kentanishida/free-pjt のプロジェクト管理のみで使用しているためハードコードで運用。他リポ展開時に inputs 化を検討する
+#           expected_project_id="PVT_kwHOBUR8Xc4A8hFH"
+#           if [ "$actual_project_id" != "$expected_project_id" ]; then
+#             echo "::error::Project ID mismatch. Expected: $expected_project_id, Got: $actual_project_id"
+#             exit 1
+#           fi
+#
+#           project_title=$(echo "$validation" | jq -r '.data.user.projectV2.title')
+#           echo "Validated project: $project_title ($actual_project_id)"
+#           echo "project_id=$actual_project_id" >> "$GITHUB_OUTPUT"
+#
+#           # 現在は kentanishida/free-pjt のプロジェクト管理のみで使用しているためハードコードで運用。他リポ展開時に inputs 化を検討する
+#           echo "Getting existing project items (all pages)..."
+#           if ! existing_issues_raw=$(gh api graphql --paginate -f query='
+#             query($endCursor: String) {
+#               user(login: "kentanishida") {
+#                 projectV2(number: 6) {
+#                   items(first: 100, after: $endCursor) {
+#                     nodes {
+#                       content {
+#                         ... on Issue {
+#                           number
+#                         }
+#                       }
+#                     }
+#                     pageInfo {
+#                       hasNextPage
+#                       endCursor
+#                     }
+#                   }
+#                 }
+#               }
+#             }
+#           ' --jq '.data.user.projectV2.items.nodes[].content.number // empty' 2>&1); then
+#             echo "::error::Failed to fetch existing project items. Response: $existing_issues_raw"
+#             exit 1
+#           fi
+#           existing_issues=$(echo "$existing_issues_raw" \
+#             | awk 'NF' \
+#             | { grep -E '^[0-9]+$' || true; } \
+#             | sort \
+#             | uniq)
+#
+#           if [ -z "$existing_issues" ] && [ -n "$existing_issues_raw" ]; then
+#             echo "::warning::Raw project items data was non-empty but no valid issue numbers were extracted. Raw (first 500 chars): ${existing_issues_raw:0:500}"
+#           fi
+#
+#           # gh issue list はローカルの git リポジトリからリポジトリを推定するため、checkout なしでは --repo の指定が必要
+#           echo "Getting all open issues..."
+#           if ! all_issues_raw=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --json number --limit 10000 2>&1); then
+#             echo "::error::Failed to fetch open issues. Response: $all_issues_raw"
+#             exit 1
+#           fi
+#           all_issues=$(echo "$all_issues_raw" \
+#             | jq -r '.[].number' \
+#             | awk 'NF' \
+#             | { grep -E '^[0-9]+$' || true; } \
+#             | sort \
+#             | uniq)
+#
+#           if [ -z "$all_issues" ]; then
+#             echo "No open issues found. Nothing to do."
+#             echo "missing_issues=" >> "$GITHUB_OUTPUT"
+#             exit 0
+#           fi
+#
+#           echo "Debug - all_issues count: $(echo "$all_issues" | { grep -c . || echo 0; })"
+#           echo "Debug - existing_issues count: $(echo "$existing_issues" | { grep -c . || echo 0; })"
+#
+#           if [ -n "$all_issues" ] && [ -n "$existing_issues" ]; then
+#             echo "$all_issues" | tr ' ' '\n' | { grep -E '^[0-9]+$' || true; } | sort > /tmp/all_issues_sorted
+#             echo "$existing_issues" | tr ' ' '\n' | { grep -E '^[0-9]+$' || true; } | sort > /tmp/existing_issues_sorted
+#             missing_issues=$(comm -23 /tmp/all_issues_sorted /tmp/existing_issues_sorted | tr '\n' ' ' | xargs)
+#           elif [ -n "$all_issues" ] && [ -z "$existing_issues" ]; then
+#             missing_issues=$(echo "$all_issues" | tr '\n' ' ' | xargs)
+#           else
+#             missing_issues=""
+#           fi
+#
+#           echo "Issues not in project: $missing_issues"
+#           delimiter="ghadelimiter_$(openssl rand -hex 8)"
+#           echo "missing_issues<<${delimiter}" >> "$GITHUB_OUTPUT"
+#           echo "$missing_issues" >> "$GITHUB_OUTPUT"
+#           echo "${delimiter}" >> "$GITHUB_OUTPUT"
+#
+#       - name: Add missing issues to project
+#         id: add-missing-issues
+#         if: steps.get-issues.outputs.missing_issues != ''
+#         env:
+#           GH_TOKEN: ${{ secrets.GH_PAT }}
+#           MISSING_ISSUES: ${{ steps.get-issues.outputs.missing_issues }}
+#           PROJECT_ID: ${{ steps.get-issues.outputs.project_id }}
+#         run: |
+#           if [ -z "$PROJECT_ID" ]; then
+#             echo "::error::PROJECT_ID is empty. The get-issues step may have failed to set it."
+#             exit 1
+#           fi
+#
+#           failed_count=0
+#           success_count=0
+#
+#           for issue_number in $MISSING_ISSUES; do
+#             if ! echo "$issue_number" | grep -qE '^[0-9]+$'; then
+#               echo "::warning::Skipping non-numeric value: $issue_number"
+#               continue
+#             fi
+#
+#             echo "Adding issue #$issue_number to project..."
+#
+#             content_id_response=""
+#             max_attempts=3
+#             for attempt in $(seq 1 $max_attempts); do
+#               raw_response=$(gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number" --include 2>&1) || true
+#
+#               if echo "$raw_response" | head -1 | grep -q '^HTTP/'; then
+#                 status_code=$(echo "$raw_response" | head -1 | awk '{print $2}' | tr -d '\r')
+#                 response_body=$(echo "$raw_response" | sed '1,/^[[:space:]]*$/d')
+#               else
+#                 echo "::warning::No HTTP response received for issue #$issue_number. Attempt $attempt/$max_attempts. Raw output (first 500 chars): ${raw_response:0:500}"
+#                 status_code=""
+#                 response_body=""
+#                 if [ "$attempt" -lt "$max_attempts" ]; then
+#                   sleep $((attempt * 5))
+#                 fi
+#                 continue
+#               fi
+#
+#               if [ "$status_code" = "200" ]; then
+#                 content_id_response=$(echo "$response_body" | jq -r '.node_id' 2>/dev/null)
+#                 break
+#               else
+#                 if [ "$status_code" = "429" ] || [ "$status_code" = "403" ]; then
+#                   warn_prefix="Forbidden or rate limited"
+#                 else
+#                   warn_prefix="Unexpected status"
+#                 fi
+#                 echo "::warning::${warn_prefix} (HTTP $status_code) for issue #$issue_number. Attempt $attempt/$max_attempts."
+#                 echo "::warning::Response body (first 500 chars): ${response_body:0:500}"
+#                 if echo "$status_code" | grep -qE '^4[0-9][0-9]$' && [ "$status_code" != "429" ] && [ "$status_code" != "403" ]; then
+#                   break
+#                 fi
+#                 if [ "$attempt" -lt "$max_attempts" ]; then
+#                   sleep $((attempt * 5))
+#                 fi
+#               fi
+#             done
+#
+#             if [ -z "$content_id_response" ] || [ "$content_id_response" = "null" ]; then
+#               echo "::warning::Failed to get node_id for issue #$issue_number after $max_attempts attempts. Last HTTP status: $status_code"
+#               failed_count=$((failed_count + 1))
+#               sleep 1
+#               continue
+#             fi
+#
+#             if ! mutation_response=$(gh api graphql -f query='
+#               mutation($projectId: ID!, $contentId: ID!) {
+#                 addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+#                   item {
+#                     id
+#                   }
+#                 }
+#               }
+#             ' -f projectId="$PROJECT_ID" -f contentId="$content_id_response" 2>&1); then
+#               echo "::warning::Failed to add issue #$issue_number to project. Response: $mutation_response"
+#               failed_count=$((failed_count + 1))
+#             elif echo "$mutation_response" | jq -e '.errors | length > 0' > /dev/null 2>&1; then
+#               error_msg=$(echo "$mutation_response" | jq -r '.errors[0].message // "Unknown error"')
+#               echo "::warning::GraphQL error adding issue #$issue_number: $error_msg"
+#               failed_count=$((failed_count + 1))
+#             elif echo "$mutation_response" | jq -e '.data.addProjectV2ItemById.item.id' > /dev/null 2>&1; then
+#               echo "Successfully added issue #$issue_number"
+#               success_count=$((success_count + 1))
+#             else
+#               echo "::warning::Unexpected response for issue #$issue_number: $mutation_response"
+#               failed_count=$((failed_count + 1))
+#             fi
+#
+#             sleep 1
+#           done
+#
+#           total=$((success_count + failed_count))
+#           echo "Results: $success_count succeeded, $failed_count failed out of $total total"
+#
+#           echo "success_count=$success_count" >> "$GITHUB_OUTPUT"
+#           echo "failed_count=$failed_count" >> "$GITHUB_OUTPUT"
+#
+#           if [ "$failed_count" -gt 0 ]; then
+#             echo "::error::$failed_count issue(s) failed to be added to the project"
+#             exit 1
+#           fi
+#
+#       - name: Summary
+#         if: always()
+#         env:
+#           MISSING_ISSUES: ${{ steps.get-issues.outputs.missing_issues }}
+#           SUCCESS_COUNT: ${{ steps.add-missing-issues.outputs.success_count }}
+#           FAILED_COUNT: ${{ steps.add-missing-issues.outputs.failed_count }}
+#         run: |
+#           if [ -z "$MISSING_ISSUES" ]; then
+#             echo "All issues are already in the project"
+#           elif [ -n "$SUCCESS_COUNT" ]; then
+#             echo "Results: $SUCCESS_COUNT succeeded, $FAILED_COUNT failed"
+#             if [ "$FAILED_COUNT" -gt 0 ]; then
+#               echo "::warning::Some issues failed to be added. Check the logs above for details."
+#             fi
+#           else
+#             echo "::warning::Add step did not complete. Check the logs above for details."
+#           fi

--- a/.github/workflows/addIssueToProject.yml
+++ b/.github/workflows/addIssueToProject.yml
@@ -2,11 +2,15 @@ name: addIssueToProject
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 14 * * *'
+  # GH_PAT 廃止作業中は実処理を停止しているため、無駄な定期実行を止める（復旧時に解除）
+  # schedule:
+  #   - cron: '0 14 * * *'
 
 jobs:
   add-issues:
     uses: ./.github/workflows/_addIssueToProject.yml
-    secrets:
-      GH_PAT: ${{ secrets.GH_PAT }}
+    # GH_PAT 廃止作業中は受け渡しを停止。受け取り側（_addIssueToProject.yml）が
+    # GH_PAT を宣言していない現状でここから渡すと secret 不整合で定義エラーになる。
+    # 復旧時はこの secrets ブロックと受け取り側の secrets 宣言を必ずセットで戻すこと（詳細は _addIssueToProject.yml 冒頭）。
+    # secrets:
+    #   GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## この PR の概要

GH_PAT 廃止に伴い、`addIssueToProject` ワークフローを「すぐ戻せる形」で一時無効化します。

## 解決したい問題

GitHub の PAT（`GH_PAT`）をセキュリティ上の理由で削除します。このトークンは `addIssueToProject` ワークフロー（caller: `.github/workflows/addIssueToProject.yml` / reusable: `_addIssueToProject.yml`）が、open issue を GitHub Projects（ProjectV2）へ自動追加するために使用しています。トークンを消すとワークフローが認証エラーで失敗するため、削除前にワークフロー側を停止する必要があります。

### 根本原因

このワークフローは **ユーザー個人所有の ProjectV2**（`user(login: "kentanishida")` の `projectV2(number: 6)`）を操作しています。これは `secrets.GITHUB_TOKEN` ではアクセスできず（`repository-projects` 権限は旧 Projects classic 用で ProjectV2 は対象外）、個人アカウントに install した GitHub App の installation token でも取得できません。そのため PAT を消した瞬間に代替が存在せず、自動化を維持したまま単純に置き換えることができません。

## 解決方法

PAT 削除のタイミングで失敗し続けないよう、実処理を停止し通知のみを残す「一時無効化」を行います。恒久的な復旧（GitHub App 移行）は別 issue #17 で扱います。

### 仕組み

- `_addIssueToProject.yml`: 実処理ステップ群を各行頭「# 」でコメントアウトして保存し、代わりに状況を知らせる `Notify temporarily disabled`（echo のみ）ステップを追加。
- `_addIssueToProject.yml`: `on.workflow_call.secrets`（`GH_PAT: required: true`）をコメントアウトし、廃止予定の secret を受け取らないようにした。
- `addIssueToProject.yml`: 無効化中の無駄な定期実行を止めるため `schedule` をコメントアウト（`workflow_dispatch` は手動確認用に残置）。callee が secret を宣言しなくなったため、caller からの `secrets.GH_PAT` 受け渡しもコメントアウト。
- 冒頭コメントに「緊急ロールバック」「恒久対応（#17）」の復旧手順を明記。

### なぜこれで解決するか

PAT を参照する箇所がアクティブな YAML 上から全て消えるため、`GH_PAT` を削除してもワークフローが認証エラーで失敗しません。手動実行しても通知 echo が出るだけで API 操作は行いません。実処理はコメントとして保全されており、各行頭の「# 」を外すだけで元へ戻せます（後述のとおり byte 完全一致を検証済み）。

### 妥当性を示す参考資料

- [Deprecation of user to organization account transformation（GitHub Changelog, 2026-01-12）](https://github.blog/changelog/2026-01-12-deprecation-of-user-to-organization-account-transformation/)
- [GitHub App と user 所有 ProjectsV2 のアクセス制約（community discussion #64849）](https://github.com/orgs/community/discussions/64849)
- [Choosing permissions for a GitHub App（GitHub Docs）](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app)

## 比較検討した他の案

- **`secrets.GITHUB_TOKEN` へ置換**: user 所有 ProjectV2 にアクセスできず必ず失敗するため不採用。
- **個人アカウント install の GitHub App**: 無人 CI の installation token では user 所有 ProjectsV2 を取得できず、`GITHUB_TOKEN` と同じく機能しないため不採用。
- **fine-grained PAT（project 権限のみ）へ置換**: PAT が残り「PAT 廃止」という目的に反するため不採用。
- **恒久対応（Organization 化 + org install GitHub App）**: これが正解だが、org 作成・移行・App 設定が必要で本 PR のスコープ外。issue #17 として切り出した。

## 変更内容の概要

- `.github/workflows/_addIssueToProject.yml`
  - 実処理 3 ステップを各行頭「# 」でコメントアウトして保全
  - `Notify temporarily disabled`（echo のみ）ステップを追加
  - `on.workflow_call.secrets`（GH_PAT）をコメントアウト
  - 冒頭に復旧手順（緊急ロールバック / 恒久対応 #17）を追記
- `.github/workflows/addIssueToProject.yml`
  - `schedule` をコメントアウト（`workflow_dispatch` は残置）
  - callee への `secrets.GH_PAT` 受け渡しをコメントアウト
  - 復旧時に両ファイルをセットで戻す旨のコメントを追記

## 既存機能への影響

- issue を Project へ自動追加する機能は停止します（恒久復旧は #17）。
- これ以外の機能・ワークフローへの影響はありません（リポジトリ内で `GH_PAT` を参照するのはこの 2 ファイルのみであることを確認済み）。
- マージ条件・デプロイ・セキュリティスキャン等のゲート機能は持たないため、停止によるセキュリティ上のデグレはありません。

## Test plan

- [ ] テストが通ること（本リポジトリに自動テストは無し）
- [ ] 型エラーがないこと（該当なし）
- [x] Lint / Format pass（`actionlint` は既存の ubicloud カスタムランナーラベル警告のみ。本変更による新規指摘なし）
- [ ] CI pass 確認（本変更で動く CI ジョブは無し）
- [x] 手動テスト（必要な場合）

## 行った動作確認

- **YAML 妥当性**: 両ファイルを Python でパースし、有効であることを確認。

  ```bash
  python3 -c "import yaml; [yaml.safe_load(open(p)) for p in ['.github/workflows/addIssueToProject.yml','.github/workflows/_addIssueToProject.yml']]; print('OK')"
  ```

  結果: `add-issues-to-project` ジョブの有効ステップは `Notify temporarily disabled` の 1 つのみ、`on` は caller=`workflow_dispatch`・reusable=`workflow_call`（必須 secret 無し）。

- **「すぐ戻せる」ことの検証**: コメントアウトした本体（247 行）から各行頭「# 」を機械的に除去した結果が、変更前（`git show HEAD:...`）の元ステップ群と **byte 完全一致**することを確認。

  ```bash
  # 区切りコメント以降の本体から「# 」を除去 → HEAD の元ステップ群と比較し IDENTICAL を確認
  ```

  結果: `restored == original steps: True`（247 行一致）。

- **静的検査**: `actionlint .github/workflows/*.yml` を実行。指摘は `ubicloud-standard-2-ubuntu-2404`（外部ランナーのカスタムラベル）の既知警告のみで、HEAD でも同一であり本変更とは無関係。

## コーディングエージェントに送られた指示文

> github の pat をセキュリテイの関係で削除するので、使用箇所があると思うのでそれを書き換えてほしいです。多分 CI の書き換えが必要かと。secrets.GITHUB_TOKEN でいけるはず。merge までよろしく

（調査の結果 `secrets.GITHUB_TOKEN` では user 所有 ProjectV2 にアクセスできないことが判明したため、ユーザーと協議のうえ「Organization 化 + GitHub App への恒久移行(#17)までの一時無効化」として実装。）

## issue に書かれた完了条件とその達成可否

- 本 PR は一時無効化を担当。恒久復旧の完了条件は #17 に記載。
- 本 PR のゴール（PAT 参照の停止・通知メッセージ・GH_PAT 受け取り停止・すぐ戻せる形）はいずれも達成。

## issue のリンク

- 恒久対応: #17
